### PR TITLE
Update README.md, fix img urls

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -8,17 +8,19 @@ Metriport helps healthcare organizations access comprehensive patient clinical h
 
 <div align="center">
   <a href="https://metriport.com?utm_source=orgreadmemain&utm_id=github">
-    <img width="786" alt="metriport is an open-source platform for healthcare data" src="./assets/main.png">
+    <img width="786" alt="metriport is an open-source platform for healthcare data" src="https://github.com/metriport/.github/blob/6c440d82b266260ed42bd3daac51fdf959facbce/assets/main.png">
   </a>
 </div>
 
+<br/>
 
-<div align="center" style="display: flex; justify-content: space-between; padding: 20px;">
+<div align="center" >
    <a href="https://metriport.com/medical?utm_source=orgreadmeapi&utm_id=github">
-    <img width="380" style="margin-right: 20px;" alt="metriport open-source universal api for healthcare data with fhir support" src="./assets/api.png">
+    <img width="380" alt="metriport open-source universal api for healthcare data with fhir support" src="https://github.com/metriport/.github/blob/6c440d82b266260ed42bd3daac51fdf959facbce/assets/api.png">
    </a>
+  &nbsp;&nbsp;
   <a href="https://metriport.com/dashboard?utm_source=orgreadmedash&utm_id=github">
-    <img width="380" alt="metriport provider dashboard for healthcare data access and management" src="./assets/dash.png">
+    <img width="380" alt="metriport provider dashboard for healthcare data access and management" src="https://github.com/metriport/.github/blob/6c440d82b266260ed42bd3daac51fdf959facbce/assets/dash.png">
    </a>
   
 </div>


### PR DESCRIPTION
Fix image URLs in our GH home page - [context](https://metriport.slack.com/archives/C041YAW030C/p1718656127739169).

Removed style as its not supported - [reference](https://github.com/orgs/community/discussions/22728#discussioncomment-3237853).

BEFORE

![image](https://github.com/metriport/.github/assets/2132564/f707bfa0-e0c4-48e7-9c78-a2a37ef37b4c)

AFTER

![image](https://github.com/metriport/.github/assets/2132564/9f59936d-0f4b-4ad7-a863-9bf16c5c760a)
